### PR TITLE
update working directory to home in aria2@.service

### DIFF
--- a/aria2/aria2@.service
+++ b/aria2/aria2@.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=forking
 User=%i
-WorkingDirectory=/home/%i
+WorkingDirectory=%h
 Environment=VAR=/var/%i
 ExecStart=/etc/systemd/scripts/aria2-start
 


### PR DESCRIPTION
According to the [spec](http://www.freedesktop.org/software/systemd/man/systemd.unit.html#idp4220800), %h is provided by systemd, we don't need to assume /home
